### PR TITLE
Fix jest script to assure local execution

### DIFF
--- a/generators/app/templates/package.json.template
+++ b/generators/app/templates/package.json.template
@@ -13,14 +13,14 @@
   ],
   "scripts": {
     "start": "node main.js",
-    "lint": "jest --config jest-eslint.config.js",
-    "lint:watch": "jest --config jest-eslint.config.js --watch",
-    "jest": "jest --config jest-test.config.js",
-    "jest:coverage": "jest --config jest-test.config.js --coverage",
-    "jest:watch": "jest --config jest-test.config.js --watch",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "lint": "npx jest --config jest-eslint.config.js",
+    "lint:watch": "npx jest --config jest-eslint.config.js --watch",
+    "jest": "npx jest --config jest-test.config.js",
+    "jest:coverage": "npx jest --config jest-test.config.js --coverage",
+    "jest:watch": "npx jest --config jest-test.config.js --watch",
+    "test": "npx jest",
+    "test:watch": "npx jest --watch",
+    "test:coverage": "npx jest --coverage"
   },
   "ntl": {
     "descriptions": {


### PR DESCRIPTION
Using npx before jest command will assure that the command is executed through the local packages and not globally